### PR TITLE
Set request/ping timeout to 30 seconds at startup

### DIFF
--- a/packages/vsf-storyblok-extension/index.js
+++ b/packages/vsf-storyblok-extension/index.js
@@ -57,7 +57,9 @@ module.exports = ({ config, db }) => {
     }, 500)
   })
 
-  db.ping().then(async (response) => {
+  db.ping({
+    requestTimeout: 30000
+  }).then(async (response) => {
     try {
       console.log('📖 : Syncing published stories!') // eslint-disable-line no-console
       await db.indices.delete({ ignore_unavailable: true, index })


### PR DESCRIPTION
Default seems to be 3 seconds, 30 seconds to wait for elasticsearch to respond to the ping request during startup seems more reasonable.

> Maybe this should be a config variable?