### PR TITLE
Fix multiple meta charset tags

### DIFF
--- a/packages/vsf-storyblok-module/components/Blok.ts
+++ b/packages/vsf-storyblok-module/components/Blok.ts
@@ -12,7 +12,7 @@ export default {
   },
   metaInfo: {
     meta: [
-      { charset: 'utf-8' }
+      { charset: 'utf-8', vmid: 'charset' }
     ]
   }
 }


### PR DESCRIPTION
This fixed the issue where multiple storyblok mixins would generate multiple <meta charset> tags in html head.