### PR TITLE
get detectWebp default value from config

### DIFF
--- a/packages/vsf-storyblok-module/components/global/Img.vue
+++ b/packages/vsf-storyblok-module/components/global/Img.vue
@@ -11,6 +11,9 @@
 
 <script>
 import { isServer } from '@vue-storefront/core/helpers'
+import get from 'lodash-es/get'
+import { config } from 'config'
+
 function canUseWebP () {
   if (!isServer) {
     const elem = document.createElement('canvas')
@@ -54,7 +57,7 @@ export default {
   props: {
     detectWebp: {
       type: Boolean,
-      default: true
+      default: get(config, 'storyblok.imageService.defaultWebp', true)
     },
     height: {
       type: Number,

--- a/packages/vsf-storyblok-module/components/global/Img.vue
+++ b/packages/vsf-storyblok-module/components/global/Img.vue
@@ -12,7 +12,7 @@
 <script>
 import { isServer } from '@vue-storefront/core/helpers'
 import get from 'lodash-es/get'
-import { config } from 'config'
+import config from 'config'
 
 function canUseWebP () {
   if (!isServer) {


### PR DESCRIPTION
The latest version forces webp as a new default.
This PR will add support to set the default webp behaviour in config.

**Usage**
Add this to local.json (base.json in my case).
```
  "storyblok": {
    "imageService": {
      "defaultWebp": false
    }
  }
```