### PR TITLE
Add TLD support for meta hreflang tags and honor storeView "disabled" setting

### DIFF
--- a/packages/vsf-storyblok-module/pages/Storyblok.vue
+++ b/packages/vsf-storyblok-module/pages/Storyblok.vue
@@ -24,7 +24,7 @@ export default {
           const storeCode = this.storeCodeFromSlug(link.full_slug)
           const locale = get(config.storeViews, [storeCode, 'i18n/defaultLocale'], storeCode)
           const tldPrefix = get(config.storeViews, [storeCode, 'tld'], undefined)
-          const href = tldPrefix ? tldPrefix + '/' + removeStoreCodeFromSlug(link.full_slug) : hreflangPrefix + link.full_slug
+          const href = tldPrefix ? tldPrefix + '/' + this.removeStoreCodeFromSlug(link.full_slug) : hreflangPrefix + link.full_slug
           return {
             rel: 'alternate',
             hreflang: locale,

--- a/packages/vsf-storyblok-module/pages/Storyblok.vue
+++ b/packages/vsf-storyblok-module/pages/Storyblok.vue
@@ -16,19 +16,33 @@ export default {
     const {hreflangPrefix} = getSettings(config.storyblok.settings)
     if (hreflangPrefix && this.story && this.story.alternates.length > 0) {
       const metaInfo = {
-        link: this.story.alternates.map(link => {
-          const storeCode = storeCodeFromRoute(link.full_slug)
+        link: this.story.alternates.filter(link => {
+          const storeCode = this.storeCodeFromSlug(link.full_slug)
+          return get(config.storeViews, [storeCode, 'disabled'], true) === false
+        })
+        .map(link => {
+          const storeCode = this.storeCodeFromSlug(link.full_slug)
           const locale = get(config.storeViews, [storeCode, 'i18n/defaultLocale'], storeCode)
+          const tldPrefix = get(config.storeViews, [storeCode, 'tld'], undefined)
+          const href = tldPrefix ? tldPrefix + '/' + removeStoreCodeFromSlug(link.full_slug) : hreflangPrefix + link.full_slug
           return {
             rel: 'alternate',
             hreflang: locale,
-            href: hreflangPrefix + link.full_slug
+            href: href
           }
         })
       }
       return metaInfo
     }
     return {}
+  },
+  methods: {
+    storeCodeFromSlug (slug) {
+      return slug.split(/\/(.+)/)[0]
+    },
+    removeStoreCodeFromSlug(slug) {
+      return slug.split(/\/(.+)/)[1]
+    }
   }
 }
 </script>

--- a/packages/vsf-storyblok-module/pages/Storyblok.vue
+++ b/packages/vsf-storyblok-module/pages/Storyblok.vue
@@ -6,7 +6,6 @@
 import config from 'config'
 import get from 'lodash.get'
 import { getSettings } from '../helpers'
-import storeCodeFromRoute from '@vue-storefront/core/lib/storeCodeFromRoute'
 import StoryblokMixin from '../components/StoryblokMixin'
 import { localizedRoute } from '@vue-storefront/core/lib/multistore'
 

--- a/packages/vsf-storyblok-module/pages/Storyblok.vue
+++ b/packages/vsf-storyblok-module/pages/Storyblok.vue
@@ -8,6 +8,7 @@ import get from 'lodash.get'
 import { getSettings } from '../helpers'
 import storeCodeFromRoute from '@vue-storefront/core/lib/storeCodeFromRoute'
 import StoryblokMixin from '../components/StoryblokMixin'
+import { localizedRoute } from '@vue-storefront/core/lib/multistore'
 
 export default {
   name: 'StoryblokPage',
@@ -23,8 +24,8 @@ export default {
         .map(link => {
           const storeCode = this.storeCodeFromSlug(link.full_slug)
           const locale = get(config.storeViews, [storeCode, 'i18n/defaultLocale'], storeCode)
-          const tldPrefix = get(config.storeViews, [storeCode, 'tld'], undefined)
-          const href = tldPrefix ? tldPrefix + '/' + this.removeStoreCodeFromSlug(link.full_slug) : hreflangPrefix + link.full_slug
+          const storeViewUrl = get(config.storeViews, [storeCode, 'url'], '')
+          const href = this.isAbsoluteUrl(storeViewUrl) ? storeViewUrl + '/' + this.removeStoreCodeFromSlug(link.full_slug) : localizedRoute(link.full_slug)
           return {
             rel: 'alternate',
             hreflang: locale,
@@ -42,6 +43,9 @@ export default {
     },
     removeStoreCodeFromSlug(slug) {
       return slug.split(/\/(.+)/)[1]
+    },
+    isAbsoluteUrl (url) {
+      return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url)
     }
   }
 }

--- a/packages/vsf-storyblok-module/pages/Storyblok.vue
+++ b/packages/vsf-storyblok-module/pages/Storyblok.vue
@@ -28,7 +28,7 @@ export default {
           return {
             rel: 'alternate',
             hreflang: locale,
-            href: href
+            href
           }
         })
       }


### PR DESCRIPTION
When creating meta hreflang tags:
- This checks if each alternate story has a corresponding **enabled** storeView before generating the hreflang tag.
- Checks if the corresponding storeView is a "subfolder" or TLD site and generates appropriate href attribute. (Before it assumed subfolder structure for all storeviews)