### PR TITLE
Force leading slash for internal links

### DIFF
--- a/packages/vsf-storyblok-module/components/global/RouterLink.vue
+++ b/packages/vsf-storyblok-module/components/global/RouterLink.vue
@@ -25,13 +25,14 @@ export default {
       storeCodeFromHeader: (state) => state.storeCode
     }),
     isExternal () {
-      return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(this.url)
+      return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(this.link.cached_url || this.link.url)
     },
     url () {
-      let url = this.link.cached_url || this.link.url
+      const formatUrl = url => this.isExternal ? url : (`/${url}`).replace(/^\/+/, '/')
+      let url = formatUrl(this.link.cached_url || this.link.url)
       const addStoreCode = get(config, 'storyblok.settings.appendStoreCodeFromHeader')
-      if (addStoreCode && this.storeCodeFromHeader && url.replace(/^\/+/).startsWith(`${this.storeCodeFromHeader}`)) {
-        return url.replace(/^\/+/).replace(`${this.storeCodeFromHeader}`, '')
+      if (addStoreCode && this.storeCodeFromHeader && url.startsWith(`/${this.storeCodeFromHeader}`)) {
+        return url.replace(`/${this.storeCodeFromHeader}`, '')
       }
       return url
     }


### PR DESCRIPTION
Fixes the problem where some links on subpages are treated as relative links rather than absolute links.