### PR TITLE
Fix false positive match of storeCode at start of link

### DIFF
--- a/packages/vsf-storyblok-module/components/global/RouterLink.vue
+++ b/packages/vsf-storyblok-module/components/global/RouterLink.vue
@@ -31,8 +31,8 @@ export default {
       const formatUrl = url => this.isExternal ? url : (`/${url}`).replace(/^\/+/, '/')
       let url = formatUrl(this.link.cached_url || this.link.url)
       const addStoreCode = get(config, 'storyblok.settings.appendStoreCodeFromHeader')
-      if (addStoreCode && this.storeCodeFromHeader && url.startsWith(`/${this.storeCodeFromHeader}`)) {
-        return url.replace(`/${this.storeCodeFromHeader}`, '')
+      if (addStoreCode && this.storeCodeFromHeader && url.startsWith(`/${this.storeCodeFromHeader}/`)) {
+        return url.replace(`/${this.storeCodeFromHeader}/`, '/')
       }
       return url
     }


### PR DESCRIPTION
There was a bug in RouterLink.vue.
It is trying to remove any leading storeCode from the link value sent from Storyblok.
Example: 
`/pl/plakaty` => `/plakaty`

The problem was when there was no leading storeCode but the initial characters of the oink matched a storeCode anyway, like this:
`/plakaty` => `akaty`

I fixed it by including the slash that follows the storeCode in the check.
