### PR TITLE
Add hreflang and canonical to metaInfo

### DIFF
--- a/packages/vsf-storyblok-module/components/StoryblokMixin.ts
+++ b/packages/vsf-storyblok-module/components/StoryblokMixin.ts
@@ -4,20 +4,10 @@ import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { KEY } from '..'
 import { StoryblokState } from '../types/State'
 import { loadScript, getStoryblokQueryParams } from '../helpers'
-import has from 'lodash-es/has'
 import get from 'lodash-es/get'
 
 export default {
   name: 'Storyblok',
-  metaInfo () {
-    if (!this.isStatic && this.story) {
-      return {
-        title: has(this.story.content, 'seo.title') && this.story.content.seo.title ? this.story.content.seo.title : this.story.name,
-        meta: has(this.story.content, 'seo.description') && this.story.content.seo.description ? [{ vmid: 'description', name: 'description', content: this.story.content.seo.description }] : []
-      }
-    }
-    return {}
-  },
   computed: {
     ...mapState(KEY, {
       loadingStory(state: StoryblokState) {

--- a/packages/vsf-storyblok-module/pages/Storyblok.vue
+++ b/packages/vsf-storyblok-module/pages/Storyblok.vue
@@ -14,7 +14,7 @@ export default {
   name: 'StoryblokPage',
   mixins: [StoryblokMixin],
   metaInfo () {
-    if (!this.isStatic && this.story) {
+    if (this.story) {
       return {
         title: get(this.story, 'content.seo.title', this.story.name),
         meta: [

--- a/packages/vsf-storyblok-module/pages/Storyblok.vue
+++ b/packages/vsf-storyblok-module/pages/Storyblok.vue
@@ -34,17 +34,17 @@ export default {
     metaHreflangLinks () {
       const {hreflangPrefix} = getSettings(config.storyblok.settings)
       if (hreflangPrefix && this.story && this.story.alternates.length > 0) {
-          const alternateHreflangLinks = this.story.alternates.filter(link => {
-            const storeCode = this.storeCodeFromSlug(link.full_slug)
+          const alternateHreflangLinks = this.story.alternates.filter(altStory => {
+            const storeCode = this.storeCodeFromSlug(altStory.full_slug)
             return get(config.storeViews, [storeCode, 'disabled'], true) === false
           })
-          .map(link => {
-            const storeCode = this.storeCodeFromSlug(link.full_slug)
+          .map(altStory => {
+            const storeCode = this.storeCodeFromSlug(altStory.full_slug)
             const storeView = get(config.storeViews, storeCode)
             return {
               rel: 'alternate',
               hreflang: get(storeView, 'seo.hreflang') || get(storeView, 'i18n.defaultLocale') || storeCode,
-              href: this.getCanonical(get(config.storeViews, storeCode), link)
+              href: this.getCanonical(get(config.storeViews, storeCode), altStory)
             }
           })
 
@@ -61,7 +61,7 @@ export default {
     getCanonical (storeView = currentStoreView(), story = this.story) {
       const storeViewUrl = get(storeView, 'url', '')
       const {hreflangPrefix} = getSettings(config.storyblok.settings)
-      const url = this.isAbsoluteUrl(storeViewUrl) ? storeViewUrl + '/' + this.removeStoreCodeFromSlug(story.full_slug) : hreflangPrefix + localizedRoute(story.full_slug)
+      const url = this.isAbsoluteUrl(storeViewUrl) ? storeViewUrl + '/' + this.removeStoreCodeFromSlug(story.full_slug) : hreflangPrefix + story.full_slug
       return url.replace(/\/home$/, '')
     },
     storeCodeFromSlug (slug) {


### PR DESCRIPTION
I removed the `metaInfo` from `StoryblokMixin.ts` because the mixin is used not only for the Storyblok pages, but also for the "block mixins". `StoryblokMixin.ts` already had an if statement so metaInfo would only run on actual Storyblok pages. So it just made more sense to put it directly in the `Storyblok.vue` page component.

* Added all `<link rel="alternate" hrefllang="z-y" href="x">` for `this.story.alternates` including a self referencing one (according to Google recommendations)
* Added `<link rel="canonical" href="x">`
* Added possibility to declare fallback values for `title`, `description` in `config.storeViews.xx.seo`
* Added `hreflang` override in `config.storeViews.xx.se.hreflang` (default value from `config.storeViews.xx.i18n.defaultLocale`)