### PR TITLE
Added placeholder property with transparent pixel as default value

### DIFF
--- a/packages/vsf-storyblok-module/components/global/Img.vue
+++ b/packages/vsf-storyblok-module/components/global/Img.vue
@@ -2,7 +2,7 @@
   <div v-if="div && lazy" v-lazy:background-image="image" :style="{ backgroundImage: `url('${placeholder}')` }">
     <slot />
   </div>
-  <div v-else-if="div" :style="{ backgroundImage: 'url(\'' + image + '\')' }">
+  <div v-else-if="div" :style="{ backgroundImage: `url('${image}')` }">
     <slot />
   </div>
   <img v-else-if="lazy" v-lazy="image" :src="placeholder">

--- a/packages/vsf-storyblok-module/components/global/Img.vue
+++ b/packages/vsf-storyblok-module/components/global/Img.vue
@@ -1,11 +1,11 @@
 <template>
-  <div v-if="div && lazy" v-lazy:background-image="image">
+  <div v-if="div && lazy" v-lazy:background-image="image" :style="{ backgroundImage: 'url(\'' + placeholder + '\')' }">
     <slot />
   </div>
   <div v-else-if="div" :style="{ backgroundImage: 'url(\'' + image + '\')' }">
     <slot />
   </div>
-  <img v-else-if="lazy" v-lazy="image">
+  <img v-else-if="lazy" v-lazy="image" :src="placeholder">
   <img v-else :src="image">
 </template>
 
@@ -48,6 +48,10 @@ export default {
     }
   },
   props: {
+    placeholder: {
+      type: String,
+      default: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=='
+    },
     detectWebp: {
       type: Boolean,
       default: get(config, 'storyblok.imageService.defaultWebp', true)

--- a/packages/vsf-storyblok-module/components/global/Img.vue
+++ b/packages/vsf-storyblok-module/components/global/Img.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="div && lazy" v-lazy:background-image="image" :style="{ backgroundImage: 'url(\'' + placeholder + '\')' }">
+  <div v-if="div && lazy" v-lazy:background-image="image" :style="{ backgroundImage: `url('${placeholder}')` }">
     <slot />
   </div>
   <div v-else-if="div" :style="{ backgroundImage: 'url(\'' + image + '\')' }">


### PR DESCRIPTION
Fix to prevent the broken image icon while waiting for lazy loaded images to appear.

Added new property `placeholder` so we can specify a lowres/lighter placeholder image to be loaded while waiting for the lazy-loaded image to appear. Set the default value as an inline transparent GIF pixel.