### PR TITLE
Fix http 500 error: Don't assume accept header exists

### DIFF
--- a/packages/vsf-storyblok-module/store/actions.ts
+++ b/packages/vsf-storyblok-module/store/actions.ts
@@ -11,7 +11,7 @@ export const actions: ActionTree<StoryblokState, RootState> = {
     if (request.headers['x-vs-store-code']) {
       dispatch('setStoreCode', request.headers['x-vs-store-code'])
     }
-    const supportsWebp = request.headers.accept.includes('image/webp')
+    const supportsWebp = request.headers.accept && request.headers.accept.includes('image/webp')
     commit('supportsWebp', supportsWebp)
   },
   async setStoreCode ({ commit, state }, storeCode) {


### PR DESCRIPTION
Any client that don't send the `accept` header in its request will crash this module and produce a http 500 error from VSF.
The problem is the code assumes ´request.headers.accept` exists when trying to find out if the client accepts wepb images.
I found the error when checking the VSF error log on prod server so apparently this is a real issue. Maybe it's just bots and crawlers but this should still be fixed.

I added a "guard" that assumes non-webp support if `request.headers.accept` doesn't exist.

This PR was tested succesfully using Requestly (Chrome addon).